### PR TITLE
Legend looks better w/themes manually reordered to match rp2040pins.csv

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -68,17 +68,17 @@ LABEL_FONT = "Courier New"
 # Misc2    #C0C0FF  #C0C0FF - not currently used?
 
 themes = [
-    {'type':'CircuitPython Name', 'fill':'#E6E6E6', 'outline':'auto', 'font-weight':'bold'},
     {'type':'Power', 'fill':'#920000', 'outline':'none', 'font-weight':'bold'},
     {'type':'GND', 'fill':'#000000', 'outline':'none', 'font-weight':'bold'},
     {'type':'Control', 'fill':'#004949', 'outline':'none', 'font-weight':'bold'},
     {'type':'Arduino', 'fill':'#00FF00', 'outline':'none', 'font-weight':'bold'},
+    {'type':'CircuitPython Name', 'fill':'#E6E6E6', 'outline':'auto', 'font-weight':'bold'},
     {'type':'Port', 'fill':'#FFFF6D', 'outline':'none', 'font-weight':'normal'},
-    {'type':'Analog', 'fill':'#DB6D00', 'outline':'none', 'font-weight':'normal'},
-    {'type':'PWM', 'fill':'#FFB6DB', 'outline':'none', 'font-weight':'normal'},
-    {'type':'UART', 'fill':'#B6DBFF', 'outline':'none', 'font-weight':'normal'},
     {'type':'SPI', 'fill':'#24FF24', 'outline':'none', 'font-weight':'normal'},
+    {'type':'UART', 'fill':'#B6DBFF', 'outline':'none', 'font-weight':'normal'},
     {'type':'I2C', 'fill':'#B66DFF', 'outline':'none', 'font-weight':'normal'},
+    {'type':'PWM', 'fill':'#FFB6DB', 'outline':'none', 'font-weight':'normal'},
+    {'type':'Analog', 'fill':'#DB6D00', 'outline':'none', 'font-weight':'normal'},
     {'type':'QT_SCL', 'fill':'#FFFF00', 'outline':'none', 'font-weight':'bold'},
     {'type':'QT_SDA', 'fill':'#0000FF', 'outline':'none', 'font-weight':'bold'},
     {'type':'ExtInt', 'fill':'#FF00FF', 'outline':'none', 'font-weight':'normal'},


### PR DESCRIPTION
Idea here is that the legend boxes match the pin mux boxes from closest-to-board to furthest. I tried looking at doing this automatically, but because the themes and MUX names don’t match (they’re remapped in the box-drawing loop) it’s just not that simple. So this looks OK for RP2040 boards but might not work as well for others (though still functional).