### PR TITLE
Accept px as units

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -1028,12 +1028,16 @@ def parse(fzpz, circuitpydef, pinoutcsv, arduinovariantfolder, substitute):
         svg_width = 25.4 * float(svg_width[:-2]) * MM_TO_PX
     elif "mm" in svg_width:
         svg_width = float(svg_width[:-2]) * MM_TO_PX
+    elif "px" in svg_width:
+        svg_width = float(svg_width[:-2])
     else:
         raise RuntimeError("Dont know units of width!", svg_width)
     if "in" in svg_height:
         svg_height = 25.4 * float(svg_height[:-2]) * MM_TO_PX
     elif "mm" in svg_height:
         svg_height = float(svg_height[:-2]) * MM_TO_PX
+    elif "px" in svg_height:
+        svg_height = float(svg_height[:-2])
     else:
         raise RuntimeError("Dont know units of width!", svg_height)
 


### PR DESCRIPTION
With what I believe was a default install of PrettyPins, I received the error, "Dont know units of width!" from `parser.py`. It happened because width was expressed in px rather than inches or mm, though I had not requested px as a unit anywhere.

The attached patch just looks for the string `px` in width and height and then strips out those characters without doing any conversion, which fits the pattern of the earlier two tests, which convert inches and mm to px.